### PR TITLE
paren mode toggle function

### DIFF
--- a/autoload/parinfer_lib.vim
+++ b/autoload/parinfer_lib.vim
@@ -755,7 +755,7 @@ function! parinfer_lib#IndentMode(text, options)
 endfunction
 
 function! parinfer_lib#ParenMode(text, options)
-  let l:result = s:ProcessText(a:text, s:INDENT_MODE, a:options)
+  let l:result = s:ProcessText(a:text, s:PAREN_MODE, a:options)
   return s:PublicResult(l:result)
 endfunction
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -84,7 +84,11 @@ function! parinfer#process_form()
   let form = data[2]
 
   " TODO! pass in cursor to second ard
-  let res = parinfer_lib#IndentMode(form, {})
+  if g:parinfer_mode == 'indent'
+    let res = parinfer_lib#IndentMode(form, {})
+  else 
+    let res = parinfer_lib#ParenMode(form, {})
+  endif
   let text = res.text
 
   call parinfer#draw(text, data[0], data[1])
@@ -134,7 +138,14 @@ function! parinfer#del_char()
   call parinfer#process_form()
 endfunction
 
-" TODO toggle modes
+function! parinfer#ToggleParinferMode()
+  if g:parinfer_mode == 'indent'
+    let g:parinfer_mode = 'paren'
+  else
+    let g:parinfer_mode = 'indent'
+  endif
+endfunction
+
 com! -bar ToggleParinferMode cal parinfer#ToggleParinferMode() 
 
 augroup parinfer


### PR DESCRIPTION
There's a small issue where this:

```clojure
(def s {:foo 1
                :bar 2})
```

Fails to format to this:

```clojure
(def s {:foo 1
        :bar 2})
```

But this:

```clojure
(def something {:foo 1
        :bar 2})
```

Seems to work properly:

```clojure
(def something {:foo 1
                :bar 2})
```

So it can still be useful.