### PR TITLE
Trigger parinfer on TextChanged for Vim 8+

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -146,8 +146,12 @@ augroup parinfer
   autocmd FileType clojure,racket,lisp vnoremap <buffer> <Tab> :call parinfer#do_indent()<cr>
   autocmd FileType clojure,racket,lisp vnoremap <buffer> <S-Tab> :call parinfer#do_undent()<cr>
 
-  " so dd and p trigger paren rebalance
-  autocmd FileType clojure,racket,lisp nnoremap <buffer> dd :call parinfer#delete_line()<cr>
-  autocmd FileType clojure,racket,lisp nnoremap <buffer> p :call parinfer#put_line()<cr>
-  " autocmd FileType clojure nnoremap <buffer> x :call parinfer#del_char()<cr>
+  if exists('#TextChanged')
+    autocmd TextChanged *.clj,*.cljs,*.cljc,*.edn,*.rkt,*.lisp call parinfer#process_form()
+  else
+    " so dd and p trigger paren rebalance
+    autocmd FileType clojure,racket,lisp nnoremap <buffer> dd :call parinfer#delete_line()<cr>
+    autocmd FileType clojure,racket,lisp nnoremap <buffer> p :call parinfer#put_line()<cr>
+    " autocmd FileType clojure nnoremap <buffer> x :call parinfer#del_char()<cr>
+  endif
 augroup END


### PR DESCRIPTION
Triggering on text change in normal mode seems to be a lot better, since text
can be modified by more than just `dd` and `p` (e.g. commenting/uncommenting a
line, deleting characters, and so on).

Would be awesome to get this working for TextChangedI as well, but I think that needs some more work.