### PR TITLE
Fix exists() test

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -146,7 +146,7 @@ augroup parinfer
   autocmd FileType clojure,racket,lisp vnoremap <buffer> <Tab> :call parinfer#do_indent()<cr>
   autocmd FileType clojure,racket,lisp vnoremap <buffer> <S-Tab> :call parinfer#do_undent()<cr>
 
-  if exists('#TextChanged')
+  if exists('##TextChanged')
     autocmd TextChanged *.clj,*.cljs,*.cljc,*.edn,*.rkt,*.lisp call parinfer#process_form()
   else
     " so dd and p trigger paren rebalance


### PR DESCRIPTION
`exists('#TextChanged')` tests whether there is something hooked to the `TextChanged` event, while `exists('##TextChanged')` tests whether Vim supports the event.