### PR TITLE
Attempt to fix borked undo (user gets caught in an undo loop)

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -74,10 +74,12 @@ endfunction
 function! parinfer#draw(res, top, bottom)
   let lines = split(a:res, "\n")
   let counter = a:top 
-  for line in lines
-    call setline(counter, line)
-    let counter += 1
-  endfor
+
+  " setline if this is not an undo
+  try
+    undojoin | call setline(counter, lines)
+  catch /E790/
+  endtry
 endfunction
 
 function! parinfer#process_form_insert()


### PR DESCRIPTION
This needs the latest Vim (8.1) with patch 245.

The idea is to invoke parinfer only during regular edits but not after an undo since invoking parinfer after an undo creates a branch in the undo tree causing previous changes to not be easily reachable and the user to be caught in an undo loop.

Not sure if the `try... undojoin` thing is the best approach - happy to use a better alternative if there is one.