### PR TITLE
Remove lockvar on g:_VIM_PARINFER_DEFAULTS

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -9,7 +9,6 @@ let g:_VIM_PARINFER_DEFAULTS = {
     \ 'mode':       "indent",
     \ 'script_dir': resolve(expand("<sfile>:p:h:h"))
     \ }
-lockvar! g:_VIM_PARINFER_DEFAULTS
 
 for s:key in keys(g:_VIM_PARINFER_DEFAULTS)
     if !exists('g:vim_parinfer_' . s:key)


### PR DESCRIPTION
I've been seeing...

    Error detected while processing .../vim_parinfer.vim
    line   11:
    E741: Value is locked: g:_VIM_PARINFER_DEFAULTS

...when running BundleInstall! for vundle.  Locking isn't adding
value, so fix is just removing the lockvar causing the error.
Manually tested as resolving the issue.