### PR TITLE
Use less conflicting mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ run
 
 ## Mappings 
 
-Parinfer is trigger on all TextChanged events within vim.
-In addition, you may use the following mapped commands:
+Parinfer is trigger on all TextChanged events within vim. If your version of
+Vim does not support the 'TextChanged' autocommand event you may use the
+following mapped commands:
 
-- `<Tab>` - indents s-expression
-- `<Tab-S>` - dedents s-expression
+- `>>` - indents s-expression
+- `<<` - dedents s-expression
 - `dd` - deletes line and balances parenthesis
 - `p` - puts line and balances parenthesis
 

--- a/doc/vim-parinfer.txt
+++ b/doc/vim-parinfer.txt
@@ -55,8 +55,8 @@ COMMANDS                                                   *parinfer-commands*
 
 MAPPINGS                                                   *parinfer-mappings*
 
-<Tab>        indents s-expression
-<S-Tab>      dedents s-expression
+>>           indents s-expression
+<<           dedents s-expression
 dd           deletes line and balances parenthesis
 p            puts line and balances parenthesis
 

--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -172,13 +172,16 @@ endfunction
 
 com! -bar ToggleParinferMode cal parinfer#ToggleParinferMode() 
 
+nnoremap <Plug>ParinferDoIndent :call parinfer#do_indent()<cr>
+nnoremap <Plug>ParinferDoUndent :call parinfer#do_undent()<cr>
+vnoremap <Plug>ParinferDoIndent :call parinfer#do_indent()<cr>
+vnoremap <Plug>ParinferDoUndent :call parinfer#do_undent()<cr>
+nnoremap <Plug>ParinferDeleteLine:call parinfer#delete_line()<cr>
+nnoremap <Plug>ParinferPutLine :call parinfer#put_line()<cr>
+
 augroup parinfer
   autocmd!
   execute "autocmd InsertLeave " . join(g:vim_parinfer_globs, ",") . " call parinfer#process_form()"
-  execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nnoremap <buffer> <Tab> :call parinfer#do_indent()<cr>"
-  execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nnoremap <buffer> <S-Tab> :call parinfer#do_undent()<cr>"
-  execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " vnoremap <buffer> <Tab> :call parinfer#do_indent()<cr>"
-  execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " vnoremap <buffer> <S-Tab> :call parinfer#do_undent()<cr>"
 
   if exists('##TextChangedI')
     execute "autocmd TextChangedI " . join(g:vim_parinfer_globs, ",") . " call parinfer#process_form_insert()"
@@ -187,8 +190,12 @@ augroup parinfer
   if exists('##TextChanged')
     execute "autocmd TextChanged " . join(g:vim_parinfer_globs, ",") . " call parinfer#process_form()"
   else
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nmap <buffer> >> <Plug>ParinferDoIndent"
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nmap <buffer> << <Plug>ParinferDoUndent"
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " vmap <buffer> >> <Plug>ParinferDoIndent"
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " vmap <buffer> << <Plug>ParinferDoUndent"
     " dd and p trigger paren rebalance
-    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nnoremap <buffer> dd :call parinfer#delete_line()<cr>"
-    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nnoremap <buffer> p  :call parinfer#put_line()<cr>"
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nmap <buffer> dd <Plug>ParinferDeleteLine"
+    execute "autocmd FileType " . join(g:vim_parinfer_filetypes, ",") . " nmap <buffer> p  <Plug>ParinferPutLine"
   endif
 augroup END


### PR DESCRIPTION
Use `>>` and `<<` for indenting and dedenting instead of `<Tab>` and `<S-Tab>`.
Mapping `<Tab>` in normal mode also overrides `<C-i>`, which is used for
jumping forward through the jumplist.

As far as I can tell, these mappings are only needed when the version
of Vim does not support the `TextChanged` autocommand event. The
mappings will no longer be defined otherwise.

This change also includes a level of indirection by introducing the
`<Plug>Parinfer*` mappings. These allow a user to more easily define
their own mappings, i.e.:

    nmap <Tab> <Plug>ParinferDoIndent
    nmap <S-Tab> <Plug>ParinferDoUndent

This also allows the `do_indent` and `do_undent` functions to be
made private (not in this change).