### PR TITLE
Add dune to supported file types.

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -4,7 +4,7 @@
 " brian@brianhurlow.com
 
 let g:_VIM_PARINFER_DEFAULTS = {
-    \ 'filetypes':  ['clojure', 'racket', 'lisp', 'scheme', 'lfe', 'fennel'],
+    \ 'filetypes':  ['clojure', 'racket', 'lisp', 'scheme', 'lfe', 'fennel', 'dune'],
     \ 'mode':       "indent",
     \ 'script_dir': resolve(expand("<sfile>:p:h:h"))
     \ }


### PR DESCRIPTION
Dune files are used by the dune build tool for OCaml and is configured
using files written in s-expressions

Tested by: Using it