### PR TITLE
Added toggleable off-mode

### DIFF
--- a/plugin/parinfer.vim
+++ b/plugin/parinfer.vim
@@ -97,6 +97,10 @@ function! parinfer#process_form_insert()
 endfunction
 
 function! parinfer#process_form()
+  if g:vim_parinfer_mode == 'off'
+    return
+  endif
+    
   let save_cursor = getpos(".")
   let data = g:Select_full_form()
 
@@ -164,6 +168,8 @@ endfunction
 function! parinfer#ToggleParinferMode()
   if g:vim_parinfer_mode == 'indent'
     let g:vim_parinfer_mode = 'paren'
+  elseif g:vim_parinfer_mode == 'paren'
+    let g:vim_parinfer_mode = 'off'
   else
     let g:vim_parinfer_mode = 'indent'
   endif


### PR DESCRIPTION
Sometimes the parinfer logic is too smart and prevents the user from freely restructuring code. This change adds an `off` mode, which can be toggled round-robin, alongside the existing `paren` and `indent` modes.
In `off` mode, the plugin does not process any forms and allows the user to freely manipulate the buffer.

It's helpful to map `ToggleParInferMode` to some key, e.g.:
`nnoremap <C-S-;> :ToggleParinferMode<CR>:echo g:vim_parinfer_mode<CR>`

Tested in `vim 9.0` and `nvim 0.7.2`